### PR TITLE
Remove toc call in search method

### DIFF
--- a/gpapi/googleplay.py
+++ b/gpapi/googleplay.py
@@ -394,7 +394,7 @@ class GooglePlayAPI(object):
 
         path = SEARCH_URL + "?c=3&q={}".format(requests.utils.quote(query))
         # FIXME: not sure if this toc call should be here
-        self.toc()
+        # self.toc()
         data = self.executeRequestApi2(path)
         if utils.hasPrefetch(data):
             response = data.preFetch[0].response

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.0.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ PROTOC_EXEC = "protoc"
 
 CURRENT_DIR = os.path.abspath( os.path.dirname( __file__ ) )
 
-__VERSION__ = '2.0.0'
+__VERSION__ = '2.0.1'
 
 class ProtobufBuilder(_build):
 


### PR DESCRIPTION
Temporarily commenting out the `self.toc` call since it is not required.
